### PR TITLE
Fix missing fmt argument in error message

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -21,7 +21,7 @@ impl Config {
 
         for path in configs {
             let c = ConfigFile::load_from(&path)
-                .with_context(|| anyhow!("Failed to load config file: {:?}"))?;
+                .with_context(|| anyhow!("Failed to load config file: {:?}", path))?;
             if let Some(config) = c {
                 debug!("Applying config from {:?}", path);
                 merged.update(config);


### PR DESCRIPTION
Without this, the error message would literally be "Failed to load config file: {:?}" with curly braces in it instead of the path.