### PR TITLE
Workaround KDE wayland bug

### DIFF
--- a/contrib/arch-audit-gtk.desktop
+++ b/contrib/arch-audit-gtk.desktop
@@ -2,4 +2,4 @@
 Type=Application
 Name=Arch Linux Security Update Notifications
 Comment=Display your current patch status
-Exec=/usr/bin/arch-audit-gtk
+Exec=/bin/sh -c "sleep 5 && exec /usr/bin/arch-audit-gtk"


### PR DESCRIPTION
When launching on KDE Wayland, if `arch-audit-gtk` starts too early it will not show up in the tray and spit out this error:

    (arch-audit-gtk:49658): Gtk-CRITICAL **: 07:18:53.737: gtk_widget_get_scale_factor: assertion 'GTK_IS_WIDGET (widget)' failed

It seems that if you launch _too early_ on KDE Wayland attempting to setup the tray icon just randomly fails (on my machine, less than 1 in 10 logins will end up with the icon). This PR adds an arbitrary delay to the autostart entry, which causes the icon to show up in the tray every time on my machine.

KDE also has the option to delay the startup of entries to after another entry has started, but none of these reliably fixed the issue in my testing (specifically the relevant ones are probably `org.kde.plasmashell` and `panel` - both had less than a 50% success rate on my machine).

Probably fixes #10 

Additional testing welcome to see if 5 seconds really is enough for all cases.